### PR TITLE
several fixes to enable ocata/pike/master controller service upgrade.

### DIFF
--- a/roles/common/tasks/glance-db-sync.yml
+++ b/roles/common/tasks/glance-db-sync.yml
@@ -1,2 +1,2 @@
 - name: openstack-glance - db sync
-  command: glance-manage --config-file=/etc/glance/glance-registry.conf db_sync
+  command: glance-manage db_sync

--- a/roles/master/compute/skip-upgrade/tasks/main.yml
+++ b/roles/master/compute/skip-upgrade/tasks/main.yml
@@ -1,13 +1,11 @@
-- name: rhos-release
+- name: tripleo repo
   include_role:
     name: common
-    tasks_from: rhos-release
+    tasks_from: tripleo-release
   vars:
-    rhos_release_osp: 11
-    rhos_release_rhel: 7.4
-    rhos_release_puddle: 7.4-testing
+    release_version: master
 
-- name: Upgrade to OSP 11
+- name: Update packages
   yum:
     name: '*'
     state: latest

--- a/roles/master/compute/upgrade/tasks/main.yml
+++ b/roles/master/compute/upgrade/tasks/main.yml
@@ -1,0 +1,17 @@
+- name: tripleo repo
+  include_role:
+    name: common
+    tasks_from: tripleo-release
+  vars:
+    release_version: master
+
+- name: Update packages
+  yum:
+    name: '*'
+    state: latest
+
+- name: restart OpenStack compute services on {{ inventory_hostname }}.
+  systemd:
+    name: "{{ item }}"
+    state: restarted
+  with_items: "{{ compute_openstack_services }}"

--- a/roles/master/controller/upgrade/tasks/main.yml
+++ b/roles/master/controller/upgrade/tasks/main.yml
@@ -19,7 +19,7 @@
 - include: ../../../common/tasks/keystone-db-sync.yml
 - include: ../../../common/tasks/cinder-db-sync.yml
 - include: ../../../common/tasks/neutron-db-sync.yml
-- include: ../../../common/tasks/sahara-db-sync.yml
+#- include: ../../../common/tasks/sahara-db-sync.yml
 - include: ../../../common/tasks/heat-db-sync.yml
 - include: ../../../common/tasks/glance-db-sync.yml
 - include: ../../../common/tasks/nova-db-sync.yml

--- a/roles/master/controller/upgrade/tasks/main.yml
+++ b/roles/master/controller/upgrade/tasks/main.yml
@@ -21,6 +21,7 @@
 - include: ../../../common/tasks/neutron-db-sync.yml
 - include: ../../../common/tasks/sahara-db-sync.yml
 - include: ../../../common/tasks/heat-db-sync.yml
+- include: ../../../common/tasks/glance-db-sync.yml
 - include: ../../../common/tasks/nova-db-sync.yml
 
 # FIXME: RHBZ#

--- a/roles/ocata/controller/upgrade/tasks/nova-cellsv2.yml
+++ b/roles/ocata/controller/upgrade/tasks/nova-cellsv2.yml
@@ -14,6 +14,7 @@
 - name: openstack-nova - Fetch rabbit_virtual_host
   command: crudini --get /etc/nova/nova.conf oslo_messaging_rabbit rabbit_virtual_host
   register: rabbit_virtual_host
+  ignore_errors: true
 
 - name: openstack-nova - create transport_url
   no_log: true

--- a/roles/pike/compute/upgrade/tasks/main.yml
+++ b/roles/pike/compute/upgrade/tasks/main.yml
@@ -1,0 +1,17 @@
+- name: tripleo repo
+  include_role:
+    name: common
+    tasks_from: tripleo-release
+  vars:
+    release_version: pike
+
+- name: Update packages
+  yum:
+    name: '*'
+    state: latest
+
+- name: restart OpenStack compute services on {{ inventory_hostname }}.
+  systemd:
+    name: "{{ item }}"
+    state: restarted
+  with_items: "{{ compute_openstack_services }}"

--- a/roles/pike/controller/upgrade/tasks/main.yml
+++ b/roles/pike/controller/upgrade/tasks/main.yml
@@ -19,7 +19,7 @@
 - include: ../../../common/tasks/keystone-db-sync.yml
 - include: ../../../common/tasks/cinder-db-sync.yml
 - include: ../../../common/tasks/neutron-db-sync.yml
-- include: ../../../common/tasks/sahara-db-sync.yml
+#- include: ../../../common/tasks/sahara-db-sync.yml
 - include: ../../../common/tasks/heat-db-sync.yml
 - include: ../../../common/tasks/glance-db-sync.yml
 - include: ../../../common/tasks/nova-db-sync.yml

--- a/roles/pike/controller/upgrade/tasks/main.yml
+++ b/roles/pike/controller/upgrade/tasks/main.yml
@@ -21,6 +21,7 @@
 - include: ../../../common/tasks/neutron-db-sync.yml
 - include: ../../../common/tasks/sahara-db-sync.yml
 - include: ../../../common/tasks/heat-db-sync.yml
+- include: ../../../common/tasks/glance-db-sync.yml
 - include: ../../../common/tasks/nova-db-sync.yml
 
 # FIXME: RHBZ#


### PR DESCRIPTION
1. glance db_sync
glance db sync with '--config' added will cause failure of 'sql_connection' not established

2. ignore errors when getting rabbit_virtual_host value from nova.conf file
rabbit_virtual_host may not be configured in nova.conf which causes failure of ansible task

3. disable sahara db sync
this may fail due to sahara service not enabled or installed.

4. add compute upgrade tasks